### PR TITLE
v0.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           pip install setuptools twine wheel
           python setup.py sdist bdist_wheel
           twine upload dist/*
+          gh release create "${{ github.ref_name }}" dist/* --title "${{ github.ref_name }}" --notes "Release ${{ github.ref_name }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,7 +36,7 @@ jobs:
           ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
           pytest -v
       - name: Release
-        if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.10'
+        if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.13'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v4
       - name: Fetch submodule tags
         working-directory: test/data/gsmo
         run: git fetch --tags origin
       - name: Install test dependencies
-        run: pip install -e .[all]
+        run: uv pip install --system -e .[all]
       - name: Test
         env:
           SHELL: /bin/bash  # Required by test_proc.py::test_pipeline_shell_executable_warning
@@ -42,7 +43,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          pip install setuptools twine wheel
+          uv pip install --system setuptools twine wheel
           python setup.py sdist bdist_wheel
           twine upload dist/*
           gh release create "${{ github.ref_name }}" dist/* --title "${{ github.ref_name }}" --notes "Release ${{ github.ref_name }}"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extras_require['all'] = sum(extras_require.values(), [ 'pyyaml', ])
 
 setup(
     name="utz",
-    version="0.20.0",
+    version="0.21.0",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires=["stdlb"],

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(
     install_requires=["stdlb"],
     extras_require=extras_require,
     url="https://github.com/runsascoded/utz",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )

--- a/src/utz/plots.py
+++ b/src/utz/plots.py
@@ -11,12 +11,19 @@ from typing import Callable, Literal, Union
 import plotly.graph_objects as go
 from IPython.display import Image
 from plotly.graph_objs import Figure
-from plotly.validators.scatter.marker import SymbolValidator
 
 from utz import err
 
 # Plotly marker names
-symbols = SymbolValidator().values[2::12]
+try:
+    # Plotly <6.2
+    from plotly.validators.scatter.marker import SymbolValidator
+    symbols = SymbolValidator().values[2::12]
+except (ImportError, ModuleNotFoundError):
+    # Plotly >=6.2: use ValidatorCache
+    from plotly.validator_cache import ValidatorCache
+    SymbolValidator = ValidatorCache.get_validator('scatter.marker', 'symbol')
+    symbols = SymbolValidator.values[2::12]
 
 
 # Env vars to fall back to, for various plot kwargs

--- a/src/utz/setup.py
+++ b/src/utz/setup.py
@@ -78,7 +78,7 @@ class Compute:
 
         return classifiers
 
-    def python_requires(self): return '>=3.9'
+    def python_requires(self): return '>=3.10'
 
     def license(self):
         if exists('LICENSE'):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -131,7 +131,7 @@ def test_num_required():
         'Usage: num-cli [OPTIONS]',
         "Try 'num-cli --help' for help.",
         '',
-        "Error: Missing option '-n' / '--num'.",
+        "Error: Invalid value for '-n' / '--num': expected value, received None",
     )
 
 

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -76,7 +76,9 @@ def test_docker_demo():
 
     [
         build_python_git_image(pv, f'python-git:{pv}')
-        for pv in ('3.7.9', '3.8.6', '3.9.1',)
+        for pv in ('3.10', '3.11', '3.12',)
     ]
 
-    assert lines('docker', 'run', 'python-git:3.9.1') == ['Python 3.9.1']
+    output = lines('docker', 'run', 'python-git:3.12')
+    assert len(output) == 1
+    assert output[0].startswith('Python 3.12.')

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -26,7 +26,7 @@ def test_setup_gsmo():
                 'author_email': 'ryan@runsascoded.com',
                 'packages': ['gsmo', 'gsmo.util'],
                 'classifiers': ['Programming Language :: Python :: 3', 'Operating System :: OS Independent'],
-                'python_requires': '>=3.9',
+                'python_requires': '>=3.10',
             }
         )
 

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -55,7 +55,7 @@ def test_now():
             (
                     o(unit= 's', ch='A', len=6, first_until='2028-07-15T14:30:34Z', len_until='3799-06-08T08:23:06Z'),
                     o(unit='ms', ch='d', len=7, first_until='2025-10-29T11:47:34.506000Z', len_until='2083-06-04T14:46:33.194000Z'),
-                    o(unit='us', ch='G', len=9, first_until='2025-06-19T02:29:50.672362Z', len_until='2406-01-02T18:06:37.841642Z'),
+                    o(unit='us', ch='H', len=9, first_until='2032-05-20T04:31:36.257258Z', len_until='2406-01-02T18:06:37.841642Z'),
             ),
             ('At4G0V', 'bTwXvhz', 'GWAZusO3r'),
         ),


### PR DESCRIPTION
## Summary
- Add Plotly 6.2+ compatibility for SymbolValidator import
- Drop Python 3.9 support, add 3.13 and 3.14 to test matrix
- Update python_requires to >=3.10
- Publish releases from Python 3.13 instead of 3.10

## Test plan
- CI will run tests on Python 3.10, 3.11, 3.12, 3.13, and 3.14
- Plotly compatibility fix handles both old and new import paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)